### PR TITLE
Fix "null" device model for Firefox OS Tablet UA

### DIFF
--- a/src/detectizr.js
+++ b/src/detectizr.js
@@ -204,7 +204,7 @@
             } else if ((that.test(/tablet/i) && !that.test(/RX-34/i)) || that.test(/FOLIO/i)) {
                 // Check if user agent is a Tablet
                 device.type = deviceTypes[1];
-                device.model = String(that.exec(/playbook/));
+                device.model = String(that.exec(/playbook/) || "");
             } else if (that.test(/Linux/i) && that.test(/Android/i) && !that.test(/Fennec|mobi|HTC.Magic|HTCX06HT|Nexus.One|SC-02B|fone.945/i)) {
                 // Check if user agent is an Android Tablet
                 device.type = deviceTypes[1];


### PR DESCRIPTION
The UA for Firefox OS tablets will be something like `Mozilla/5.0 (Tablet; Android; rv:26.0) Gecko/26.0 Firefox/26.0`. The current test `if ((that.test(/tablet/i) && !that.test(/RX-34/i)) || that.test(/FOLIO/i))` assumes it's a Blackberry (I'm guessing), but since there's no match on `/playbook/`, `device.model` is set to null. Which means you get a silly "null" class added to the `documentElement`.

This patch sets it to the empty string instead, which makes more sense. :)
