### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Detectizr
+# Detectizr
 [![Build Status](https://secure.travis-ci.org/barisaydinoglu/Detectizr.png?branch=master)](https://travis-ci.org/barisaydinoglu/Detectizr)
 [![Stories in Ready](https://badge.waffle.io/barisaydinoglu/detectizr.png?label=ready)](https://waffle.io/barisaydinoglu/detectizr)
 [![devDependency Status](https://david-dm.org/barisaydinoglu/detectizr/dev-status.png?theme=shields.io)](https://david-dm.org/barisaydinoglu/detectizr#info=devDependencies)
@@ -24,7 +24,7 @@ Device models of tv, mobile and tablet are being detected.
 
 Code quality of Detectizr is validated via [JSLint](http://www.jslint.com "JSLint") & [JSHint](http://www.jshint.com "JSHint").
 
-##Sample Usage
+## Sample Usage
 
 This is a library that uses your trusty little Modernizr to give you the possibility of specifying required features for a certain stylesheet.
 Using it is a simple matter, illustrated in the following excerpt:
@@ -46,12 +46,12 @@ Just remember to include Modernizr before Detectizr, and you're good to go!
 
 Licensed under MIT license.
 
-##Note for Modernizr 3.x
+## Note for Modernizr 3.x
 
 You will need to have a build of Modernizr with the addTest (Modernizr.addTest()) option.
 If done from the website, you can find it 
 
-##Other interesting projects
+## Other interesting projects
 
 * [Modernizr](https://github.com/Modernizr/Modernizr "Modernizr") is required for Detectizer. Remember to put Modernizr before Detectizr.
 * [Categorizr](https://github.com/bjankord/Categorizr "Categorizr") is a server side device and OS detection script wirtten in PHP. Detectizr inspired by its device detection.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
